### PR TITLE
Rogerio.Guimaraes path fix

### DIFF
--- a/BasicSetup/CountryMetaData.py
+++ b/BasicSetup/CountryMetaData.py
@@ -1,3 +1,6 @@
+import sys
+sys.path.append('.')
+
 from BasicSetupUtilities.MetaDataBuilder import CountryMetaDataFile
 
 CountryMetaDataFile().addCountry("USA", "US", "United States", "USD")

--- a/BasicSetup/Credentials.py
+++ b/BasicSetup/Credentials.py
@@ -1,3 +1,6 @@
+import sys
+sys.path.append('.')
+
 from BasicSetupUtilities.CredentialsStoreBuilder import DataSourceCredentials
 
 

--- a/DataIOUtilities/DataLib.py
+++ b/DataIOUtilities/DataLib.py
@@ -1,3 +1,6 @@
+import sys
+sys.path.append('.')
+
 import glob
 import os
 import pandas as pd

--- a/SampleSignal/0_SignalDataLibrary.py
+++ b/SampleSignal/0_SignalDataLibrary.py
@@ -1,3 +1,6 @@
+import sys
+sys.path.append('.')
+
 from BasicSetupUtilities.MetaDataBuilder import CountryMetaDataFile
 from DataIOUtilities.DataLib import DataLib, DatastreamPulls
 

--- a/SampleSignal/1_ExampleCode.py
+++ b/SampleSignal/1_ExampleCode.py
@@ -1,3 +1,6 @@
+import sys
+sys.path.append('.')
+
 from BasicSetupUtilities.MetaDataBuilder import CountryMetaDataFile
 from DataIOUtilities.DataLib import DataLib
 

--- a/SampleSignal/DataBrowser.ipynb
+++ b/SampleSignal/DataBrowser.ipynb
@@ -8,6 +8,10 @@
    },
    "outputs": [],
    "source": [
+    "import sys\n",
+    "sys.path.append('..')\n",
+    "\n",
+    
     "import matplotlib.pyplot as plt\n",
     "from BasicSetupUtilities.MetaDataBuilder import CountryMetaDataFile\n",
     "from DataIOUtilities.DataLib import DataLib, DatastreamPulls"

--- a/SampleSignal/ScratchPad.ipynb
+++ b/SampleSignal/ScratchPad.ipynb
@@ -8,6 +8,10 @@
    },
    "outputs": [],
    "source": [
+    "import sys\n",
+    "sys.path.append('..')\n",
+    "\n",
+    
     "from BasicSetupUtilities.MetaDataBuilder import CountryMetaDataFile\n",
     "from DataIOUtilities.DataLib import DataLib\n",
     "import matplotlib.pyplot as plt\n",


### PR DESCRIPTION
The problem of the Python environment not being able to "find" the parent directory to use the personalized classes happened to me in multiple files, and this pull request simply adds two lines to the beginning of the files that include the parent directory  in PATH.

In Python scripts, it is:

import sys
sys.path.append('.')

In Python notebooks, it is:

import sys
sys.path.append('..')

I did not change the file SampleSignal/Python_Demo.ipynb since it already had its own suggested solution to the problem.

